### PR TITLE
[Untested] Added Support For Party And Friends Extended For Bungeecord

### DIFF
--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -75,6 +75,18 @@
     <dependencies>
         <dependency>
             <groupId>de.simonsator</groupId>
+            <artifactId>Party-and-Friends-MySQL-Edition-Spigot-API</artifactId>
+            <version>1.5.1</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>be.maximvdw</groupId>
+                    <artifactId>MVdWPlaceholderAPI</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>de.simonsator</groupId>
             <artifactId>Spigot-Party-API-For-RedisBungee</artifactId>
             <version>1.0.2-SNAPSHOT</version>
             <scope>provided</scope>

--- a/bedwars-plugin/pom.xml
+++ b/bedwars-plugin/pom.xml
@@ -23,6 +23,10 @@
 
     <repositories>
         <repository>
+            <id>simonsators-repo</id>
+            <url>https://simonsator.de/repo/</url>
+        </repository>
+        <repository>
             <id>citizens</id>
             <url>https://repo.citizensnpcs.co/</url>
         </repository>
@@ -70,6 +74,18 @@
 
     <dependencies>
         <dependency>
+            <groupId>de.simonsator</groupId>
+            <artifactId>Spigot-Party-API-For-RedisBungee</artifactId>
+            <version>1.0.2-SNAPSHOT</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>be.maximvdw</groupId>
+                    <artifactId>MVdWPlaceholderAPI</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
             <version>3.0.0</version>
@@ -78,7 +94,7 @@
         <dependency>
             <groupId>de.simonsator</groupId>
             <artifactId>FakePAFSpigot</artifactId>
-            <version>1.0.4</version>
+            <version>1.0.5</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/BedWars.java
@@ -70,6 +70,7 @@ import com.andrei1058.bedwars.support.papi.PAPISupport;
 import com.andrei1058.bedwars.support.papi.SupportPAPI;
 import com.andrei1058.bedwars.support.party.NoParty;
 import com.andrei1058.bedwars.support.party.PAF;
+import com.andrei1058.bedwars.support.party.PAFBungeecordRedisApi;
 import com.andrei1058.bedwars.support.party.Parties;
 import com.andrei1058.bedwars.support.preloadedparty.PrePartyListener;
 import com.andrei1058.bedwars.support.vault.*;
@@ -305,7 +306,7 @@ public class BedWars extends JavaPlugin {
             }
         } else if (getServerType() == ServerType.MULTIARENA || getServerType() == ServerType.SHARED) {
             registerEvents(new ArenaSelectorListener(), new BlockStatusListener());
-            if (getServerType() == ServerType.MULTIARENA){
+            if (getServerType() == ServerType.MULTIARENA) {
                 registerEvents(new JoinListenerMultiArena());
             } else {
                 registerEvents(new JoinListenerShared());
@@ -314,7 +315,7 @@ public class BedWars extends JavaPlugin {
 
         registerEvents(new WorldLoadListener());
 
-        if (!(getServerType() == ServerType.BUNGEE && autoscale)){
+        if (!(getServerType() == ServerType.BUNGEE && autoscale)) {
             registerEvents(new JoinHandlerCommon());
         }
 
@@ -345,14 +346,16 @@ public class BedWars extends JavaPlugin {
         Bukkit.getScheduler().runTaskLater(this, () -> {
             if (config.getYml().getBoolean(ConfigPath.GENERAL_CONFIGURATION_ALLOW_PARTIES)) {
 
-                    if (getServer().getPluginManager().isPluginEnabled("Parties")) {
-                        getLogger().info("Hook into Parties (by AlessioDP) support!");
-                        party = new Parties();
-                    }
-                    else if (Bukkit.getServer().getPluginManager().isPluginEnabled("PartyAndFriends")){
-                        getLogger().info("Hook into Party and Friends (by Simonsator) support!");
-                        party = new PAF();
-                    }
+                if (getServer().getPluginManager().isPluginEnabled("Parties")) {
+                    getLogger().info("Hook into Parties (by AlessioDP) support!");
+                    party = new Parties();
+                } else if (Bukkit.getServer().getPluginManager().isPluginEnabled("PartyAndFriends")) {
+                    getLogger().info("Hook into Party and Friends for Spigot (by Simonsator) support!");
+                    party = new PAF();
+                } else if (Bukkit.getServer().getPluginManager().isPluginEnabled("Spigot-Party-API-PAF")) {
+                    getLogger().info("Hook into Spigot Party API for Party and Friends Extended (by Simonsator) support!");
+                    party = new PAFBungeecordRedisApi();
+                }
 
                 if (party instanceof NoParty) {
                     party = new com.andrei1058.bedwars.support.party.Internal();

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/PAF.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/PAF.java
@@ -3,48 +3,52 @@ package com.andrei1058.bedwars.support.party;
 import com.andrei1058.bedwars.api.party.Party;
 import de.simonsator.partyandfriends.api.pafplayers.OnlinePAFPlayer;
 import de.simonsator.partyandfriends.api.pafplayers.PAFPlayerManager;
+import de.simonsator.partyandfriends.api.party.PartyManager;
+import de.simonsator.partyandfriends.api.party.PlayerParty;
 import org.bukkit.entity.Player;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PAF implements Party {
-    //Party and Friends Support by JT122406
+    //Party and Friends for Spigot Support by JT122406
     @Override
     public boolean hasParty(Player p) {
-        OnlinePAFPlayer p1 = PAFPlayerManager.getInstance().getPlayer(p);
-        if((p1.getParty() == null) || p1.getParty().isInParty(p1) == false)
-            return false;
-        else
-            return true;
+        return getPAFParty(p) == null;
+    }
+
+    private PlayerParty getPAFParty(Player p) {
+        OnlinePAFPlayer pafPlayer = PAFPlayerManager.getInstance().getPlayer(p);
+        return PartyManager.getInstance().getParty(pafPlayer);
     }
 
     @Override
     public int partySize(Player p) {
-        if (hasParty(p) == false) return 0;
-        else {
-            return PAFPlayerManager.getInstance().getPlayer(p).getParty().getAllPlayers().size();
-        }
+        PlayerParty party = getPAFParty(p);
+        if (party == null)
+            return 0;
+        return party.getAllPlayers().size();
     }
 
     @Override
     public boolean isOwner(Player p) {
-        if (hasParty(p) == false) return  false;
-        else {
-            return PAFPlayerManager.getInstance().getPlayer(p).getParty().isLeader(PAFPlayerManager.getInstance().getPlayer(p));
-        }
+        OnlinePAFPlayer pafPlayer = PAFPlayerManager.getInstance().getPlayer(p);
+        PlayerParty party = PartyManager.getInstance().getParty(pafPlayer);
+        if (party == null)
+            return false;
+        return party.isLeader(pafPlayer);
     }
 
     @Override
     public List<Player> getMembers(Player owner) {
-        ArrayList<Player> players = new ArrayList<>();
-        if (hasParty(owner) == false) return players;
-        ArrayList<OnlinePAFPlayer> playersPAF = new ArrayList<>();
-        OnlinePAFPlayer p1 = PAFPlayerManager.getInstance().getPlayer(owner);
-        for (int i = 0; i < p1.getParty().getAllPlayers().size(); i++) {
-            players.add(p1.getParty().getAllPlayers().get(i).getPlayer());
+        ArrayList<Player> playerList = new ArrayList<>();
+        PlayerParty party = getPAFParty(owner);
+        if (party == null)
+            return playerList;
+        for (OnlinePAFPlayer players : party.getAllPlayers()) {
+            playerList.add(players.getPlayer());
         }
-        return players;
+        return playerList;
     }
 
     @Override
@@ -65,7 +69,10 @@ public class PAF implements Party {
 
     @Override
     public boolean isMember(Player owner, Player check) {
-        return PAFPlayerManager.getInstance().getPlayer(owner).getParty().isInParty(PAFPlayerManager.getInstance().getPlayer(check));
+        PlayerParty party = getPAFParty(owner);
+        if (party == null)
+            return false;
+        return party.isInParty(PAFPlayerManager.getInstance().getPlayer(check));
     }
 
     @Override

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/PAFBungeecordRedisApi.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/PAFBungeecordRedisApi.java
@@ -1,0 +1,87 @@
+package com.andrei1058.bedwars.support.party;
+
+import com.andrei1058.bedwars.api.party.Party;
+import de.simonsator.partyandfriends.spigot.api.pafplayers.PAFPlayer;
+import de.simonsator.partyandfriends.spigot.api.pafplayers.PAFPlayerManager;
+import de.simonsator.partyandfriends.spigot.api.party.PartyManager;
+import de.simonsator.partyandfriends.spigot.api.party.PlayerParty;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PAFBungeecordRedisApi implements Party {
+    //Party and Friends Extended for BungeeCord Support by JT122406
+    @Override
+    public boolean hasParty(Player p) {
+        return getPAFParty(p) == null;
+    }
+
+    private PlayerParty getPAFParty(Player p) {
+        PAFPlayer pafPlayer = PAFPlayerManager.getInstance().getPlayer(p.getUniqueId());
+        return PartyManager.getInstance().getParty(pafPlayer);
+    }
+
+    @Override
+    public int partySize(Player p) {
+        PlayerParty party = getPAFParty(p);
+        if (party == null)
+            return 0;
+        return party.getAllPlayers().size();
+    }
+
+    @Override
+    public boolean isOwner(Player p) {
+        PAFPlayer pafPlayer = PAFPlayerManager.getInstance().getPlayer(p.getUniqueId());
+        PlayerParty party = PartyManager.getInstance().getParty(pafPlayer);
+        if (party == null)
+            return false;
+        return party.isLeader(pafPlayer);
+    }
+
+    @Override
+    public List<Player> getMembers(Player owner) {
+        ArrayList<Player> playerList = new ArrayList<>();
+        PlayerParty party = getPAFParty(owner);
+        if (party == null)
+            return playerList;
+        for (PAFPlayer players : party.getAllPlayers()) {
+            playerList.add(Bukkit.getPlayer(players.getUniqueId()));
+        }
+        return playerList;
+    }
+
+    @Override
+    public void createParty(Player owner, Player... members) {
+    }
+
+    @Override
+    public void addMember(Player owner, Player member) {
+    }
+
+    @Override
+    public void removeFromParty(Player member) {
+    }
+
+    @Override
+    public void disband(Player owner) {
+    }
+
+    @Override
+    public boolean isMember(Player owner, Player check) {
+        PlayerParty party = getPAFParty(owner);
+        if (party == null)
+            return false;
+        return party.isInParty(PAFPlayerManager.getInstance().getPlayer(check.getUniqueId()));
+    }
+
+    @Override
+    public void removePlayer(Player owner, Player target) {
+    }
+
+    @Override
+    public boolean isInternal() {
+        return false;
+    }
+}

--- a/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/PAFBungeecordRedisApi.java
+++ b/bedwars-plugin/src/main/java/com/andrei1058/bedwars/support/party/PAFBungeecordRedisApi.java
@@ -25,10 +25,7 @@ public class PAFBungeecordRedisApi implements Party {
 
     @Override
     public int partySize(Player p) {
-        PlayerParty party = getPAFParty(p);
-        if (party == null)
-            return 0;
-        return party.getAllPlayers().size();
+        return getMembers(p).size();
     }
 
     @Override
@@ -47,7 +44,9 @@ public class PAFBungeecordRedisApi implements Party {
         if (party == null)
             return playerList;
         for (PAFPlayer players : party.getAllPlayers()) {
-            playerList.add(Bukkit.getPlayer(players.getUniqueId()));
+            Player bukkitPlayer = Bukkit.getPlayer(players.getUniqueId());
+            if (bukkitPlayer != null)
+                playerList.add(bukkitPlayer);
         }
         return playerList;
     }


### PR DESCRIPTION
- Added support for [Party and Friends Extended Edition for Bungeecord](https://www.spigotmc.org/resources/party-and-friends-extended-edition-for-bungeecord-velocity-supports-1-7-1-18.10123/) 
- The use of [Spigot Party API for Party and Friends Extended](https://www.spigotmc.org/resources/spigot-party-api-for-party-and-friends-extended-redisbungee-required.39751/) is required
- I was not able to test this implementation
- An update for FakePAFSpigot is required